### PR TITLE
Show tokens dashboard if the last currency has 0 amount

### DIFF
--- a/ElvUI_BenikUI/modules/dashboard/tokens.lua
+++ b/ElvUI_BenikUI/modules/dashboard/tokens.lua
@@ -118,6 +118,7 @@ function mod:UpdateTokens()
 		end
 	end)
 
+	local atLeastOneToken = false
 	for _, id in pairs(Currency) do
 		local name, amount, icon, weeklyMax, totalMax, isDiscovered = mod:GetTokenInfo(id)
 		if name then
@@ -200,12 +201,13 @@ function mod:UpdateTokens()
 					self.tokenFrame.name = name
 
 					tinsert(BUI.TokensDB, self.tokenFrame)
-				else
-					holder:Hide()
+					atLeastOneToken = true
 				end
 			end
 		end
 	end
+
+	if atLeastOneToken == false then holder:Hide() end
 
 	tsort(BUI.TokensDB, sortFunction)
 


### PR DESCRIPTION
The loop to populate the panel would incorrectly hide the entire panel if the last currency in the list had 0 amount. Switched the loop logic to only hide if there are no currencies to show in the panel.

For issue #13 