### PR TITLE
Add Justice Points and Valor Points to token dashboard

### DIFF
--- a/ElvUI_BenikUI/modules/dashboard/options.lua
+++ b/ElvUI_BenikUI/modules/dashboard/options.lua
@@ -32,6 +32,8 @@ local dungeonTokens = {
 	102, -- Emblem of Valor
 	2589, -- Sidereal Essence
 	2711, -- Defiler's Scourgestone
+	395, -- Justice Points
+	396, -- Valor Points
 }
 
 local pvpTokens = {

--- a/ElvUI_BenikUI/modules/dashboard/tokens.lua
+++ b/ElvUI_BenikUI/modules/dashboard/tokens.lua
@@ -47,6 +47,8 @@ local Currency = {
 	102, -- Emblem of Valor
 	2589, -- Sidereal Essence
 	2711, -- Defiler's Scourgestone
+	395, -- Justice Points
+	396, -- Valor Points
 }
 
 local function Icon_OnEnter(self)


### PR DESCRIPTION
Add the new Cata dungeon currencies to the token dashboard. Only Justice Points are testable atm since Valor Points won't be obtainable until Cata release on 5/20